### PR TITLE
Uneval invalid pointers as `isize` literals

### DIFF
--- a/frontend/exporter/src/constant_utils.rs
+++ b/frontend/exporter/src/constant_utils.rs
@@ -24,6 +24,7 @@ pub enum ConstantLiteral {
     Char(char),
     Float(String, FloatTy),
     Int(ConstantInt),
+    PtrNoProvenance(u128),
     Str(String),
     ByteStr(Vec<u8>),
 }
@@ -146,6 +147,7 @@ impl From<ConstantExpr> for Expr {
                         }
                     }
                     Float(f, ty) => LitKind::Float(f, LitFloatType::Suffixed(ty)),
+                    PtrNoProvenance(p) => LitKind::Int(p, LitIntType::Unsigned(UintTy::Usize)),
                     ByteStr(raw) => LitKind::ByteStr(raw, StrStyle::Cooked),
                     Str(raw) => LitKind::Str(raw, StrStyle::Cooked),
                 };


### PR DESCRIPTION
When unevaluation fails to dereference a pointer, its value as an `isize` should just be read and used instead.

Right now this could cause a typing issue in clients, since a literal of type `IntTy::Isize` is assigned to a reference/pointer, but that's preferable to just crashing. Otherwise a new constant expression could be added, e.g. `ConstantExprKind::PtrNoProvenance(i128)`, but that's maybe overkill?

This fixes translation of e.g. `core::ptr::null<T>`