### PR TITLE
fix order problem

### DIFF
--- a/frontend/exporter/src/rustc_utils.rs
+++ b/frontend/exporter/src/rustc_utils.rs
@@ -389,8 +389,14 @@ pub fn dyn_self_ty<'tcx>(
             ty::Binder::dummy(ty::ExistentialPredicate::Projection(proj))
         });
 
-    let preds =
-        tcx.mk_poly_existential_predicates_from_iter([main_pred].into_iter().chain(ty_constraints));
+    // sort before calling `mk_poly_existential_predicates`
+    use crate::rustc_middle::ty::ExistentialPredicateStableCmpExt;
+    let mut preds: Vec<_> = [main_pred].into_iter().chain(ty_constraints).collect();
+    preds.sort_by(|a, b| {
+        a.skip_binder().stable_cmp(tcx, &b.skip_binder())
+    });
+
+    let preds = tcx.mk_poly_existential_predicates(&preds);
     let ty = tcx.mk_ty_from_kind(ty::Dynamic(preds, re_erased, ty::DynKind::Dyn));
     let ty = normalize(tcx, typing_env, ty);
     Some(ty)


### PR DESCRIPTION
Now there should be no complain from `mk_poly_existential_predicates` about the order of the predicates. Note that previously, Mac & Linux may produce different comparison results. The sorting added should prevent this problem.