### PR TITLE
AssocFn with vtable_receiver

### DIFF
--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -441,9 +441,7 @@ fn gen_dyn_sig<'tcx>(
     let container_args = {
         let container_def_id = assoc_item.container_id(tcx);
         let container_generics = tcx.generics_of(container_def_id);
-        args.map(|args| {
-            tcx.mk_args_from_iter(args.iter().take(container_generics.count()))
-        })
+        args.map(|args| args.truncate_to(tcx, container_generics))
     };
 
     let dyn_self: ty::Ty = match assoc_item.container {

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -500,7 +500,7 @@ fn gen_dyn_sig<'tcx>(
                     return Some(normalized_sig.sinto(s));
                 }
             }
-            None
+            panic!("No principal trait found in dyn_self: {:?}", dyn_self);
         }
         _ => {
             // If it's not a dyn trait, something went wrong

--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -481,6 +481,8 @@ fn gen_dyn_sig<'tcx>(
         ty::Dynamic(preds, _, _) => {
             // Find the principal trait predicate
             for pred in preds.iter() {
+                // Safe to use `skip_binder` because we know the predicate we built in dyn_self_ty
+                // has no bound vars
                 if let ty::ExistentialPredicate::Trait(trait_ref) = pred.skip_binder() {
                     // Build full args: dyn_self + trait args
                     // Note: trait_ref.args doesn't include Self (it's existential), so we prepend dyn_self


### PR DESCRIPTION
This is to work with AeneasVerif/charon#814 . With the `vtable_safe` (`bool`) changed to `vtable_receiver` (`Option<Ty>`), the `VtableMethod` is now free from the `Ty` parameters.