### PR TITLE
Add vtable signature for closure

### DIFF
--- a/frontend/exporter/src/types/new/full_def.rs
+++ b/frontend/exporter/src/types/new/full_def.rs
@@ -410,6 +410,13 @@ pub enum FullDefKind<Body> {
         drop_glue: Option<Body>,
         /// Info required to construct a virtual `Drop` impl for this closure.
         destruct_impl: Box<VirtualTraitImpl>,
+        /// The function signature when this closure is used as `FnMut` (or `Fn`) in a vtable.
+        /// `None` if this closure does not support `FnMut` or `Fn`.
+        /// `Some(sig)` if this closure implements `FnMut` (or `Fn`),
+        /// where `sig` is the trait method declaration's signature with `Self` 
+        /// replaced by `dyn Trait` and associated types normalized (same as vtable_sig in `AssocFn`).
+        fn_mut_vtable_sig: Option<PolyFnSig>,
+        fn_vtable_sig: Option<PolyFnSig>,
     },
 
     // Constants
@@ -549,6 +556,38 @@ fn gen_vtable_sig<'tcx>(
 
     // Instantiate and normalize the signature.
     let method_decl_sig = tcx.fn_sig(method_decl_id).instantiate(tcx, trait_args);
+    let normalized_sig = normalize(tcx, s.typing_env(), method_decl_sig);
+
+    Some(normalized_sig.sinto(s))
+}
+
+#[cfg(feature = "rustc")]
+fn gen_closure_vtable_sig<'tcx>(
+    // The state that owns the method DefId
+    s: &impl UnderOwnerState<'tcx>,
+    // args: Option<ty::GenericArgsRef<'tcx>>,
+    // The `Fn` or `FnMut` trait reference of the closure
+    fn_or_fn_mut_ref: Option<ty::TraitRef<'tcx>>,
+) -> Option<PolyFnSig> {
+    let fn_or_fn_mut_ref = fn_or_fn_mut_ref?;
+    let tcx = s.base().tcx;
+
+    // Get AssocItems of `Fn` or `FnMut`
+    let assoc_item = tcx.associated_items(fn_or_fn_mut_ref.def_id);
+    // Pick `call` or `call_mut`
+    let call_method = assoc_item.in_definition_order().
+        next().map(|elem| elem).unwrap();
+    // Get its signature
+    let fn_decl_sig = tcx.fn_sig(call_method.def_id);
+    // Generate type of shim receiver
+    let dyn_self = dyn_self_ty(tcx, s.typing_env(), fn_or_fn_mut_ref).unwrap();
+    // Construct signature with dyn_self
+    let mut full_args = vec![ty::GenericArg::from(dyn_self)];
+    full_args.extend(fn_or_fn_mut_ref.args[1..].iter());
+    let trait_args = tcx.mk_args(&full_args);
+
+    // Instantiate and normalize the signature.
+    let method_decl_sig = fn_decl_sig.instantiate(tcx, trait_args);
     let normalized_sig = normalize(tcx, s.typing_env(), method_decl_sig);
 
     Some(normalized_sig.sinto(s))
@@ -822,6 +861,14 @@ where
             let fn_mut_trait = tcx.lang_items().fn_mut_trait().unwrap();
             let fn_trait = tcx.lang_items().fn_trait().unwrap();
             let destruct_trait = tcx.lang_items().destruct_trait().unwrap();
+
+            let fn_mut_ref = matches!(closure.kind(), FnMut | Fn)
+                .then(|| ty::TraitRef::new(tcx, fn_mut_trait, trait_args));
+
+            let fn_ref = matches!(closure.kind(), Fn)
+                .then(|| ty::TraitRef::new(tcx, fn_trait, trait_args));
+
+
             FullDefKind::Closure {
                 param_env: get_param_env(s, args),
                 is_const: tcx.constness(def_id) == rustc_hir::Constness::Const,
@@ -840,6 +887,8 @@ where
                     .then(|| virtual_impl_for(s, ty::TraitRef::new(tcx, fn_mut_trait, trait_args))),
                 fn_impl: matches!(closure.kind(), Fn)
                     .then(|| virtual_impl_for(s, ty::TraitRef::new(tcx, fn_trait, trait_args))),
+                fn_mut_vtable_sig: gen_closure_vtable_sig(s, fn_mut_ref),
+                fn_vtable_sig: gen_closure_vtable_sig(s, fn_ref),
             }
         }
         kind @ (RDefKind::Const { .. }


### PR DESCRIPTION
This PR adds vtable signatures of Fn and FnMut Trait for closures, which are needed in translate_vtable_shim in Charon, as discussed in the PR [Supporting vtables for closures](https://github.com/AeneasVerif/charon/pull/872#discussion_r2508511229).